### PR TITLE
Fix responses in ParamLengthLimiter cleanser

### DIFF
--- a/lib/rack/cleanser/param_length_limiter.rb
+++ b/lib/rack/cleanser/param_length_limiter.rb
@@ -50,11 +50,6 @@ module Rack
         traverse_hash(params) do |val|
           check_val(val)
         end
-      rescue => e
-        warn "\e[1mv: Error raised from ParamLengthLimiter Middleware\e[0m:"
-        warn e.message
-        warn e.backtrace
-        warn "\e[1m^: Error raised from ParamLengthLimiter Middleware\e[0m:"
       ensure
         env["rack.input"].rewind
       end

--- a/lib/rack/cleanser/param_length_limiter.rb
+++ b/lib/rack/cleanser/param_length_limiter.rb
@@ -37,7 +37,6 @@ module Rack
         case val
         when String then
           if val.length > max_length
-            warn "\e[1mLength is over #{max_length}! (#{val.length})\e[0m"
             raise RequestTooLargeException, "#{val.length} >= #{max_length}"
           end
         end


### PR DESCRIPTION
There was some rescue clause which prevented exception from being propagated. This caused unexpected behaviour, and test failures.  The rescue clause was doing nothing but displaying debug information of little value, therefore it has been removed. Other likewise debug messages have been removed as well.