### PR TITLE
Do not use exceptions for control flow

### DIFF
--- a/lib/rack/cleanser.rb
+++ b/lib/rack/cleanser.rb
@@ -46,6 +46,13 @@ module Rack
         limit_param_length!(env)
         filter_bad_uri_encoding!(env)
       end
+
+      # Produces an erroneous response in JSON format.
+      def error_response(error_code, error_message)
+        json_h = { error_message: error_message }
+        headers = { "Content-Type" => "application/json" }
+        [error_code, headers, [json_h.to_json]]
+      end
     end
 
     def initialize(app)
@@ -53,13 +60,7 @@ module Rack
     end
 
     @oversize_response = lambda { |_env, exn|
-      [
-        413,
-        { "Content-Type" => "application/json" },
-        [{
-          error_message: "Request entity too large, #{exn.message}",
-        }.to_json],
-      ]
+      error_response(413, "Request entity too large, #{exn.message}")
     }
 
     def call(env)

--- a/lib/rack/cleanser/param_length_limiter.rb
+++ b/lib/rack/cleanser/param_length_limiter.rb
@@ -6,8 +6,6 @@
 #
 module Rack
   class Cleanser
-    class RequestTooLargeException < RuntimeError; end
-
     class ParamLengthLimiter
       def initialize(name, options, block)
         @name               = name
@@ -37,7 +35,8 @@ module Rack
         case val
         when String then
           if val.length > max_length
-            raise RequestTooLargeException, "#{val.length} >= #{max_length}"
+            msg = "Request entity too large, #{val.length} >= #{max_length}"
+            Rack::Cleanser::halt_with_error(413, msg)
           end
         end
       end


### PR DESCRIPTION
Exceptions are for errors, not for regular control flow.  They carry human-readable error description for programmer, including a stack trace.  There is another construct more suitable here: throw&catch. The #throw method accepts arbitrary objects which become a return value of #catch method.  As a consequence, it's way easier to generate proper responses right inside particular cleanser.