### PR TITLE
Test that requests with non-UTF-8 URLs are filtered out

### DIFF
--- a/lib/rack/cleanser.rb
+++ b/lib/rack/cleanser.rb
@@ -6,6 +6,7 @@ require "rack/cleanser/version"
 require "forwardable"
 require "json"
 require "pp"
+require "action_controller/metal/exceptions"
 
 module Rack
   class Cleanser


### PR DESCRIPTION
Ensure that headers `HTTP_REFERER`, `PATH_INFO`, `QUERY_STRING`, `REQUEST_PATH`, `REQUEST_URI`, and `HTTP_X_FORWARDED_HOST` consist of percent-encoded (if necessary) UTF-8 characters. In other case, a HTTP 404 should be returned, see #20.