### PR TITLE
Remove irrelevant parameter constraints on authenticity_token parameter

### DIFF
--- a/lib/rack/cleanser/invalid_uri_encoding.rb
+++ b/lib/rack/cleanser/invalid_uri_encoding.rb
@@ -87,11 +87,6 @@ module Rack
         env["rack.input"].rewind
 
         check_encoding(request_params)
-
-        # make sure the authenticity token is a string
-        request_params.keys.each do |key|
-          halt_with_404 if key =~ HEADER_AUTH_TOKEN
-        end
       end
 
       def halt_with_404

--- a/lib/rack/cleanser/regexps.rb
+++ b/lib/rack/cleanser/regexps.rb
@@ -9,8 +9,6 @@ module Rack
 
       # A percent sign character which is not followed by two hex digits
       LONE_PERCENT_SIGN = /%(?![0-9a-fA-F]{2})/
-
-      HEADER_AUTH_TOKEN = /\Aauthenticity_token\[(.)*\]\z/
     end
   end
 end


### PR DESCRIPTION
Request parameters should be constrained with some other tools, for instance Rails routes or https://rubygems.org/gems/stronger_parameters gem.