### PR TITLE
Don't require Rubocop automatically

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in rack-cleanser.gemspec
 gemspec
 
+gem "rubocop", require: false
 gem "simplecov", require: false, group: :test

--- a/gemfiles/Rack-1.gemfile
+++ b/gemfiles/Rack-1.gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec path: ".."
 
 gem "rack", "~> 1.0"
+gem "rubocop", require: false

--- a/gemfiles/Rack-2.gemfile
+++ b/gemfiles/Rack-2.gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec path: ".."
 
 gem "rack", "~> 2.0"
+gem "rubocop", require: false


### PR DESCRIPTION
Rubocop uses refinements and some other things which aren't compatible with Rubinius.  Requiring it automatically in Gemfile causes problems, and actually is not necessary, as Rubocop is always invoked via its own executable.